### PR TITLE
Use Context.getDatabasePath() instead of hard-coding DB_PATH

### DIFF
--- a/hackertracker/src/main/java/com/shortstack/hackertracker/Adapter/DatabaseAdapter.java
+++ b/hackertracker/src/main/java/com/shortstack/hackertracker/Adapter/DatabaseAdapter.java
@@ -25,9 +25,6 @@ import java.util.Locale;
  */
 public class DatabaseAdapter extends SQLiteOpenHelper {
 
-    //The Android's default system path of your application database.
-    private static String DB_PATH = "/data/data/com.shortstack.hackertracker/databases/";
-
     private static String DB_NAME = "hackertracker.sqlite";
 
     private static int DB_VERSION = 206;
@@ -91,7 +88,7 @@ public class DatabaseAdapter extends SQLiteOpenHelper {
         SQLiteDatabase checkDB = null;
 
         try{
-            String myPath = DB_PATH + DB_NAME;
+            String myPath = myContext.getDatabasePath(DB_NAME).getPath();
             checkDB = SQLiteDatabase.openDatabase(myPath, null, SQLiteDatabase.OPEN_READWRITE);
             checkDB.setLocale(Locale.getDefault());
             checkDB.setLockingEnabled(true);
@@ -123,7 +120,7 @@ public class DatabaseAdapter extends SQLiteOpenHelper {
         InputStream myInput = myContext.getAssets().open(DB_NAME);
 
         // Path to the just created empty db
-        String outFileName = DB_PATH + DB_NAME;
+        String outFileName = myContext.getDatabasePath(DB_NAME).getPath();
 
         //Open the empty db as the output stream
         OutputStream myOutput = new FileOutputStream(outFileName);
@@ -145,7 +142,7 @@ public class DatabaseAdapter extends SQLiteOpenHelper {
     public void openDataBase() throws SQLException{
 
         //Open the database
-        String myPath = DB_PATH + DB_NAME;
+        String myPath = myContext.getDatabasePath(DB_NAME).getPath();
         myDataBase = SQLiteDatabase.openDatabase(myPath, null, SQLiteDatabase.OPEN_READWRITE);
 
     }

--- a/hackertracker/src/main/java/com/shortstack/hackertracker/Adapter/DatabaseAdapterStarred.java
+++ b/hackertracker/src/main/java/com/shortstack/hackertracker/Adapter/DatabaseAdapterStarred.java
@@ -20,9 +20,6 @@ import java.util.Locale;
  */
 public class DatabaseAdapterStarred extends SQLiteOpenHelper {
 
-    //The Android's default system path of your application database.
-    private static String DB_PATH = "/data/data/com.shortstack.hackertracker/databases/";
-
     private static String DB_NAME = "starred.sqlite";
 
     private static int DB_VERSION = 41;
@@ -84,7 +81,7 @@ public class DatabaseAdapterStarred extends SQLiteOpenHelper {
         SQLiteDatabase checkDB = null;
 
         try{
-            String myPath = DB_PATH + DB_NAME;
+            String myPath = myContext.getDatabasePath(DB_NAME).getPath();
             checkDB = SQLiteDatabase.openDatabase(myPath, null, SQLiteDatabase.NO_LOCALIZED_COLLATORS | SQLiteDatabase.OPEN_READWRITE);
             checkDB.setLocale(Locale.getDefault());
             checkDB.setLockingEnabled(true);
@@ -116,7 +113,7 @@ public class DatabaseAdapterStarred extends SQLiteOpenHelper {
         InputStream myInput = myContext.getAssets().open(DB_NAME);
 
         // Path to the just created empty db
-        String outFileName = DB_PATH + DB_NAME;
+        String outFileName = myContext.getDatabasePath(DB_NAME).getPath();
 
         //Open the empty db as the output stream
         OutputStream myOutput = new FileOutputStream(outFileName);
@@ -138,7 +135,7 @@ public class DatabaseAdapterStarred extends SQLiteOpenHelper {
     public void openDataBase() throws SQLException {
 
         //Open the database
-        String myPath = DB_PATH + DB_NAME;
+        String myPath = myContext.getDatabasePath(DB_NAME).getPath();
         myDataBase = SQLiteDatabase.openDatabase(myPath, null, SQLiteDatabase.NO_LOCALIZED_COLLATORS | SQLiteDatabase.OPEN_READWRITE);
 
     }

--- a/hackertracker/src/main/java/com/shortstack/hackertracker/Adapter/DatabaseAdapterVendors.java
+++ b/hackertracker/src/main/java/com/shortstack/hackertracker/Adapter/DatabaseAdapterVendors.java
@@ -24,9 +24,6 @@ import java.util.Locale;
  */
 public class DatabaseAdapterVendors extends SQLiteOpenHelper {
 
-    //The Android's default system path of your application database.
-    private static String DB_PATH = "/data/data/com.shortstack.hackertracker/databases/";
-
     private static String DB_NAME = "vendors.sqlite";
 
     private static int DB_VERSION = 6;
@@ -87,7 +84,7 @@ public class DatabaseAdapterVendors extends SQLiteOpenHelper {
         SQLiteDatabase checkDB = null;
 
         try{
-            String myPath = DB_PATH + DB_NAME;
+            String myPath = myContext.getDatabasePath(DB_NAME).getPath();
             checkDB = SQLiteDatabase.openDatabase(myPath, null, SQLiteDatabase.OPEN_READWRITE);
             checkDB.setLocale(Locale.getDefault());
             checkDB.setLockingEnabled(true);
@@ -119,7 +116,7 @@ public class DatabaseAdapterVendors extends SQLiteOpenHelper {
         InputStream myInput = myContext.getAssets().open(DB_NAME);
 
         // Path to the just created empty db
-        String outFileName = DB_PATH + DB_NAME;
+        String outFileName = myContext.getDatabasePath(DB_NAME).getPath();
 
         //Open the empty db as the output stream
         OutputStream myOutput = new FileOutputStream(outFileName);
@@ -141,7 +138,7 @@ public class DatabaseAdapterVendors extends SQLiteOpenHelper {
     public void openDataBase() throws SQLException{
 
         //Open the database
-        String myPath = DB_PATH + DB_NAME;
+        String myPath = myContext.getDatabasePath(DB_NAME).getPath();
         myDataBase = SQLiteDatabase.openDatabase(myPath, null, SQLiteDatabase.OPEN_READWRITE);
 
     }


### PR DESCRIPTION
This makes it possible to have multiple versions of the app (with
different package names) installed side-by-side.