### PR TITLE
Fixed issue with images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ If you find any bugs with the app, please create an issue.
 <h2>Android Images</h2>
 <table border="0">
   <tr>
-    <td>
-    <img src="https://lh3.googleusercontent.com/FyRzanja7nqg3tfXEuPCJmvKS2VuZ1Mke5l8G0AB2nil9Avvj_y4AVFnjpzBpaEtHPlq=h900-rw" width="250" height="446"/>
-    </td>
+<td>
+<img src="https://lh3.googleusercontent.com/FyRzanja7nqg3tfXEuPCJmvKS2VuZ1Mke5l8G0AB2nil9Avvj_y4AVFnjpzBpaEtHPlq=h900-rw" width="250" height="446"/>
+</td>
 
-    <td>
-    <img src="https://lh3.googleusercontent.com/iwUdxXvzKr454R53Cj49ZRZYSa0b7e55K_tcQGQeTzpOdWQeM-3NHDpnxb5FMI6mOvw=h900-rw" width="250" height="446" />
-    </td>
+<td>
+<img src="https://lh3.googleusercontent.com/iwUdxXvzKr454R53Cj49ZRZYSa0b7e55K_tcQGQeTzpOdWQeM-3NHDpnxb5FMI6mOvw=h900-rw" width="250" height="446" />
+</td>
 
-    <td>
-    <img src="https://lh3.googleusercontent.com/ViM6gngKRz_mnkR8I5EGfAfGRX8IlvmzdF0W54GxKOy-mqIfZzWXXl3kPTaKzc3CoQ0=h900-rw" width="250" height="446" />
-    </td>
+<td>
+<img src="https://lh3.googleusercontent.com/ViM6gngKRz_mnkR8I5EGfAfGRX8IlvmzdF0W54GxKOy-mqIfZzWXXl3kPTaKzc3CoQ0=h900-rw" width="250" height="446" />
+</td>
   <tr>
 </table>
 


### PR DESCRIPTION
Markdown was treating the `<td>` blocks as code (indented too much). 
Removed the indentations, which ruins the nice formatting, but gets the images to show up.