### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ If you find any bugs with the app, please create an issue.
 
 <h2>Android Images</h2>
 <div>
-<img src="https://lh3.googleusercontent.com/FyRzanja7nqg3tfXEuPCJmvKS2VuZ1Mke5l8G0AB2nil9Avvj_y4AVFnjpzBpaEtHPlq=h900-rw" width="250" height="446"/>
-<img src="https://lh3.googleusercontent.com/iwUdxXvzKr454R53Cj49ZRZYSa0b7e55K_tcQGQeTzpOdWQeM-3NHDpnxb5FMI6mOvw=h900-rw" width="250" height="446" />
-<img src="https://lh3.googleusercontent.com/ViM6gngKRz_mnkR8I5EGfAfGRX8IlvmzdF0W54GxKOy-mqIfZzWXXl3kPTaKzc3CoQ0=h900-rw" width="250" height="446" />
+<img src="https://lh3.googleusercontent.com/FyRzanja7nqg3tfXEuPCJmvKS2VuZ1Mke5l8G0AB2nil9Avvj_y4AVFnjpzBpaEtHPlq=h900" width="250" height="446"/>
+<img src="https://lh3.googleusercontent.com/iwUdxXvzKr454R53Cj49ZRZYSa0b7e55K_tcQGQeTzpOdWQeM-3NHDpnxb5FMI6mOvw=h900" width="250" height="446" />
+<img src="https://lh3.googleusercontent.com/ViM6gngKRz_mnkR8I5EGfAfGRX8IlvmzdF0W54GxKOy-mqIfZzWXXl3kPTaKzc3CoQ0=h900" width="250" height="446" />
 </div>
 
 <h2>iOS Version</h2>


### PR DESCRIPTION
On Firefox the images doen't show up, Firefox doesn't support WebP images. With this change google will serve a standard png image. See https://optimus.keycdn.com/support/webp-support/