### PR TITLE
Adding cert subject verification to wifi config

### DIFF
--- a/hackertracker/src/main/java/com/shortstack/hackertracker/views/WifiHelperViewHolder.kt
+++ b/hackertracker/src/main/java/com/shortstack/hackertracker/views/WifiHelperViewHolder.kt
@@ -77,6 +77,7 @@ class WifiHelperViewHolder(private val view: View) : RecyclerView.ViewHolder(vie
                     eapMethod = WifiEnterpriseConfig.Eap.PEAP
                     phase2Method = WifiEnterpriseConfig.Phase2.MSCHAPV2
                     caCertificate = certificate
+                    altSubjectMatch = "DNS:wifireg.defcon.org"
                 }
             }
 


### PR DESCRIPTION
In an attempt to get the NOC's configs right, I think this is what's needed to fight against MitM attacks as this will require it to check the auth server's cert names.

Warning - I'm not a kotlin programmer so kinda guessing the property format here in the apply, but seems to make sense. I am pretty certain that it is that property and it is that value.