### PR TITLE
Update WifiHelperViewHolder.kt

### DIFF
--- a/hackertracker/src/main/java/com/shortstack/hackertracker/views/WifiHelperViewHolder.kt
+++ b/hackertracker/src/main/java/com/shortstack/hackertracker/views/WifiHelperViewHolder.kt
@@ -24,7 +24,7 @@ class WifiHelperViewHolder(private val view: View) : RecyclerView.ViewHolder(vie
 
     companion object {
         private const val INSTALL_KEYSTORE_CODE = 1001
-        private const val WIFI_URL = "https://wifireg.defcon.org/android.php"
+        private const val WIFI_URL = "https://wifireg.defcon.org/android.html"
 
         fun inflate(parent: ViewGroup): WifiHelperViewHolder {
             val view = LayoutInflater.from(parent.context).inflate(R.layout.wifi_item, parent, false)


### PR DESCRIPTION
.php path no longer exists for WiFi reg, replace with .html extension which is what's currently used for DC30.

Side note: I would like to be a Goon to better escalate these kinds of hot fixes and things behind the scenes next year if possible. Thanks for your consideration